### PR TITLE
Add Makefile option to generate code from proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,22 @@ endif
 
 -include $(DEVGRPCGO_PATH)/makefiles/protoc.mk
 
+SRC_PROTO_PATH = ./path/to/proto/files
+GO_PROTO_PATH = ./path/to/proto/gen/code
+
 # Add your custom targets here.
 
+## Generate code from proto file(s)
+proto-gen: proto-gen-code
+```
+
+In case you want to generate the swagger doc too, use the option `proto-gen-code-swagger` instead of `proto-gen-code`. The variable `SWAGGER_PATH` should be overwritten with the path where to save the `swagger.json`
+
+```Makefile
+...
+
+## Generate code from proto file(s)
+proto-gen: proto-gen-code-swagger
 ```
 
 #### In combination with github.com/bool64/dev
@@ -106,4 +120,6 @@ endif
 ## Run tests
 test: test-unit
 
+## Generate code from proto file(s)
+proto-gen: proto-gen-code
 ```

--- a/makefiles/protoc.mk
+++ b/makefiles/protoc.mk
@@ -5,8 +5,28 @@ PWD ?= $(shell pwd)
 DEVGRPCGO_PATH ?= $(PWD)/vendor/github.com/dohernandez/dev-grpc
 DEVGRPC_SCRIPTS ?= $(DEVGRPCGO_PATH)/scripts
 
+ifeq ($(strip $(SRC_PROTO_PATH)),)
+	$(error SRC_PROTO_PATH is not set)
+endif
+
+ifeq ($(strip $(GO_PROTO_PATH)),)
+	$(error GO_PROTO_PATH is not set)
+endif
+
+# Override in app Makefile to control build target, example SWAGGER_PATH=./resources/swagger
+SWAGGER_PATH ?= .
+
 ## Check/install protoc tool
 protoc-cli:
 	@bash $(DEVGRPC_SCRIPTS)/protoc-gen-cli.sh
 
-.PHONY: protoc-cli
+## Generate code from proto file(s)
+proto-gen-code: protoc-cli
+	protoc --proto_path=$(SRC_PROTO_PATH) $(SRC_PROTO_PATH)/*.proto  --go_opt=paths=source_relative --go_out=:$(GO_PROTO_PATH)
+
+## Generate code from proto file(s) and swagger doc
+proto-gen-code-swagger: protoc-cli
+	protoc --proto_path=$(SRC_PROTO_PATH) $(SRC_PROTO_PATH)/*.proto  --go_opt=paths=source_relative --go_out=:$(GO_PROTO_PATH) --go-grpc_opt=paths=source_relative --go-grpc_out=:$(GO_PROTO_PATH) --grpc-gateway_opt=paths=source_relative --grpc-gateway_out=:$(GO_PROTO_PATH) --openapiv2_out=:$(SWAGGER_PATH)
+
+
+.PHONY: protoc-cli proto-gen-code proto-gen-code-swagger


### PR DESCRIPTION
Add Makefile option to generate code from proto.

There were added two Makefile option:
1.  **proto-gen-code** to generate code from the proto files.
2. **proto-gen-code-swagger** to generate code and swagger api doc from the proto files.